### PR TITLE
update Ubuntu and nu-validator versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.10
+FROM ubuntu:18.04
 MAINTAINER Plamen Tanov "ptanov@setelis.com"
 
 RUN apt-get update && apt-get -y upgrade
@@ -14,7 +14,7 @@ ADD ./resources/supervisord.conf /etc/supervisor/supervisord.conf
 RUN sed 's/Allow Private IPs = no/Allow Private IPs = yes/' -i /etc/w3c/validator.conf
 RUN sed 's/#HTML5/HTML5/' -i /etc/w3c/validator.conf 
 
-ADD https://github.com/validator/validator/releases/download/15.6.29/vnu.jar_15.6.29.zip /root/build/
+ADD https://github.com/validator/validator/releases/download/18.11.5/vnu.jar_18.11.5.zip /root/build/
 RUN unzip -j /root/build/vnu*.zip -d /root/build/validator.nu
 
 RUN apt-get clean


### PR DESCRIPTION
update Ubuntu version to 18.04, update nu-validator to version 18.11.5
(tested)